### PR TITLE
Rename findlib to findlib.internal and use custom META

### DIFF
--- a/META.findlib.template
+++ b/META.findlib.template
@@ -1,0 +1,5 @@
+# DUNE_GEN
+description = "Package manager"
+requires = "findlib.internal"
+requires(toploop) += "findlib.top"
+requires(create_toploop) += "findlib.top"

--- a/src/findlib/dune
+++ b/src/findlib/dune
@@ -4,11 +4,11 @@
   (public_name ocamlfind)
   (modules ocaml_args frontend)
   (flags (:standard -w -3-6-27-32-33-50))
-  (libraries findlib unix))
+  (libraries findlib.internal unix))
 
 (library
   (name findlib)
-  (public_name findlib)
+  (public_name findlib.internal)
   (modules findlib fl_args fl_lint fl_package_base fl_metascanner
     fl_metatoken fl_split fl_meta fl_topo findlib_config)
   (flags (:standard -w -6-27-32-33-50))
@@ -18,7 +18,7 @@
   (name findlib_top)
   (public_name findlib.top)
   (wrapped false)
-  (libraries findlib)
+  (libraries findlib.internal)
   (modules topfind)
   (flags (:standard -I +compiler-libs)))
 
@@ -26,7 +26,7 @@
   (name findlib_dynload)
   (public_name findlib.dynload)
   (wrapped false)
-  (libraries findlib dynlink)
+  (libraries findlib.internal dynlink)
   (modules fl_dynload))
 
 (rule


### PR DESCRIPTION
The current dune port is a bit inaccurate as it renames `findlib.internal` to `findlib` and it doesn't compose well with `mdx` for instance.

This is fixed by using a `META.findlib.template` and renaming the dune library.