### PR TITLE
Avoid eager self-init

### DIFF
--- a/src/findlib/topfind.ml.in
+++ b/src/findlib/topfind.ml.in
@@ -8,7 +8,7 @@ let predicates = ref ("toploop" :: Findlib.recorded_predicates());;
      Findlib, hence we maintain our own list
    *)
 
-let directories = ref [ Findlib.ocaml_stdlib() ];;
+let directories = ref [];;
 
 
 (* Note: Sys.interactive is always _true_ during toploop startup.
@@ -43,7 +43,7 @@ let revised_syntax () = syntax "camlp4r";;
 
 let add_dir d =
   let d = Fl_split.norm_dir d in
-  if not (List.mem d !directories) then begin
+  if not (d = Findlib.ocaml_stdlib()) && not (List.mem d !directories) then begin
     Topdirs.dir_directory d;
     directories := d :: !directories;
     !log (d ^ ": added to search path")


### PR DESCRIPTION
Findlib is supposed to load lazily but linking with Topfind made it load
immediately.
Which made findlib looks for its config file and eventually crash before the
user had a change to call Findlib.init_manually.